### PR TITLE
avoid TypeError in hex() cast

### DIFF
--- a/switcheo/neo/test_neo_utils.py
+++ b/switcheo/neo/test_neo_utils.py
@@ -61,6 +61,15 @@ transaction_array = [{
                                 {
                                     'usage': 32,
                                     'data': '592c8a46a0d06c600f06c994d1f25e7283b8a2fe'
+                                }, {
+                                    'usage': 129,
+                                    'data': '592c8a46a0d06c600f06c994d1f25e7283b8a2fe'
+                                }, {
+                                    'usage': 144,
+                                    'data': '592c8a46a0d06c600f06c994d1f25e7283b8a2fe'
+                                }, {
+                                    'usage': 2,
+                                    'data': '592c8a46a0d06c600f06c994d1f25e7283b8a2fe'
                                 }
                             ],
                             'inputs': [
@@ -164,7 +173,7 @@ class TestNeoUtils(unittest.TestCase):
                          signed_transaction)
 
     def test_sign_array(self):
-        signed_array = {'e30a7fdf-779c-4623-8f92-8a961450d843': 'b1b821d7aa3c3d388370eba8e910de5c3605fcae2d584b0e89e932658f6b335a6aac65c52928e6eebf85919464897b8966a5a4dbcfd92eb28a3ae88299533f2c', '7dac087c-3709-48ea-83e1-83eadfc4cbe5': 'b1b821d7aa3c3d388370eba8e910de5c3605fcae2d584b0e89e932658f6b335a6aac65c52928e6eebf85919464897b8966a5a4dbcfd92eb28a3ae88299533f2c'}
+        signed_array = {'7dac087c-3709-48ea-83e1-83eadfc4cbe5': 'b1b821d7aa3c3d388370eba8e910de5c3605fcae2d584b0e89e932658f6b335a6aac65c52928e6eebf85919464897b8966a5a4dbcfd92eb28a3ae88299533f2c', 'e30a7fdf-779c-4623-8f92-8a961450d843': '0d2a9565124b7d1d709cbd6a1b039296f50921572780490621cbaa0d1055a6027cbce4307030179d332cb1adc59599d766dfdac094a74a13a1bc10a5b84c93ed'}
         self.assertEqual(sign_array(messages=transaction_array, private_key_hex=testnet_privatekey_hexstring),
                          signed_array)
 

--- a/switcheo/neo/transactions.py
+++ b/switcheo/neo/transactions.py
@@ -38,9 +38,9 @@ def serialize_transaction_attribute(attr):
         raise ValueError('Transaction attribute data is larger than the Maximum allowed attribute size.')
     out = num2hexstring(attr['usage'])
     if attr['usage'] == 0x81:
-        out += num2hexstring(len(attr['data']) // 2)
+        out += num2hexstring(len(attr['data']) / 2)
     elif attr['usage'] == 0x90 or attr['usage'] >= 0xf0:
-        out += num2varint(len(attr['data']) // 2)
+        out += num2varint(len(attr['data']) / 2)
     if attr['usage'] == 0x02 or attr['usage'] == 0x03:
         out += attr['data'][2:64]
     else:

--- a/switcheo/neo/transactions.py
+++ b/switcheo/neo/transactions.py
@@ -38,9 +38,9 @@ def serialize_transaction_attribute(attr):
         raise ValueError('Transaction attribute data is larger than the Maximum allowed attribute size.')
     out = num2hexstring(attr['usage'])
     if attr['usage'] == 0x81:
-        out += num2hexstring(len(attr['data']) / 2)
+        out += num2hexstring(len(attr['data']) // 2)
     elif attr['usage'] == 0x90 or attr['usage'] >= 0xf0:
-        out += num2varint(len(attr['data']) / 2)
+        out += num2varint(len(attr['data']) // 2)
     if attr['usage'] == 0x02 or attr['usage'] == 0x03:
         out += attr['data'][2:64]
     else:

--- a/switcheo/neo/transactions.py
+++ b/switcheo/neo/transactions.py
@@ -38,9 +38,9 @@ def serialize_transaction_attribute(attr):
         raise ValueError('Transaction attribute data is larger than the Maximum allowed attribute size.')
     out = num2hexstring(attr['usage'])
     if attr['usage'] == 0x81:
-        out += num2hexstring(len(attr['data']) / 2)
+        out += num2hexstring(len(attr['data']) // 2)
     elif attr['usage'] == 0x90 or attr['usage'] >= 0xf0:
-        out += num2varint(len(attr['data']) / 2)
+        out += num2varint(len(attr['data']) // 2)
     if attr['usage'] == 0x02 or attr['usage'] == 0x03:
         out += attr['data'][2:64]
     else:
@@ -58,8 +58,8 @@ def serialize_transaction_output(txn_output):
 
 
 def serialize_witness(witness):
-    invocation_len = num2varint(len(witness['invocationScript']) / 2)
-    verification_len = num2varint(len(witness['verificationScript']) / 2)
+    invocation_len = num2varint(len(witness['invocationScript']) // 2)
+    verification_len = num2varint(len(witness['verificationScript']) // 2)
     return invocation_len + witness['invocationScript'] + verification_len + witness['verificationScript']
 
 


### PR DESCRIPTION
the result of the division was a float. This lead to a TypeError in the num2hexstring function in switcheo/utils.py where the value is casted to a hex string. 