### PR TITLE
Add Market Order function and change Order API to quantity

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open("README.rst", "r") as fh:
 setup(
     name='switcheo',
     python_requires='>=3.6',
-    version='0.3.2',
+    version='0.3.3',
     author='Keith Smith',
     author_email='keith.scotts@gmail.com',
     license='MIT License',

--- a/switcheo/authenticated_client.py
+++ b/switcheo/authenticated_client.py
@@ -29,7 +29,7 @@ from eth_utils import to_wei
 class AuthenticatedClient(PublicClient):
 
     def __init__(self,
-                 blockchain="neo",
+                 blockchain='neo',
                  contract_version='V2',
                  api_url='https://test-api.switcheo.network/',
                  api_version='/v2'):
@@ -389,14 +389,14 @@ class AuthenticatedClient(PublicClient):
         api_params = self.sign_execute_deposit_function[self.blockchain](deposit_params, private_key)
         return self.request.post(path='/deposits/{}/broadcast'.format(deposit_id), json_data=api_params)
 
-    def order(self, pair, side, price, amount, private_key, use_native_token=True, order_type="limit"):
+    def order(self, pair, side, price, quantity, private_key, use_native_token=True, order_type="limit"):
         """
         This function is a wrapper function around the create and execute order functions to help make this processes
         simpler for the end user by combining these requests in 1 step.
         Execution of this function is as follows::
 
             order(pair="SWTH_NEO", side="buy",
-                  price=0.0002, amount=100, private_key=kp,
+                  price=0.0002, quantity=100, private_key=kp,
                   use_native_token=True, order_type="limit")
 
         The expected return result for this function is the same as the execute_order function::
@@ -446,8 +446,8 @@ class AuthenticatedClient(PublicClient):
         :type side: str
         :param price: The price target for this trade.
         :type price: float
-        :param amount: The amount of the asset being exchanged in the trade.
-        :type amount: float
+        :param quantity: The amount of the asset being exchanged in the trade.
+        :type quantity: float
         :param private_key: The Private Key (ETH) or KeyPair (NEO) for the wallet being used to sign deposit message.
         :type private_key: KeyPair or str
         :param use_native_token: Flag to indicate whether or not to pay fees with the Switcheo native token.
@@ -457,17 +457,17 @@ class AuthenticatedClient(PublicClient):
         :return: Dictionary of the transaction on the order book.
         """
         create_order = self.create_order(private_key=private_key, pair=pair, side=side, price=price,
-                                         amount=amount, use_native_token=use_native_token,
+                                         quantity=quantity, use_native_token=use_native_token,
                                          order_type=order_type)
         return self.execute_order(order_params=create_order, private_key=private_key)
 
-    def create_order(self, pair, side, price, amount, private_key, use_native_token=True, order_type="limit",
+    def create_order(self, pair, side, price, quantity, private_key, use_native_token=True, order_type="limit",
                      otc_address=None):
         """
         Function to create an order for the trade pair and details requested.
         Execution of this function is as follows::
 
-            create_order(pair="SWTH_NEO", side="buy", price=0.0002, amount=100, private_key=kp,
+            create_order(pair="SWTH_NEO", side="buy", price=0.0002, quantity=100, private_key=kp,
                          use_native_token=True, order_type="limit")
 
         The expected return result for this function is as follows::
@@ -560,8 +560,8 @@ class AuthenticatedClient(PublicClient):
         :type side: str
         :param price: The price target for this trade.
         :type price: float
-        :param amount: The amount of the asset being exchanged in the trade.
-        :type amount: float
+        :param quantity: The amount of the asset being exchanged in the trade.
+        :type quantity: float
         :param private_key: The Private Key (ETH) or KeyPair (NEO) for the wallet being used to sign deposit message.
         :type private_key: KeyPair or str
         :param use_native_token: Flag to indicate whether or not to pay fees with the Switcheo native token.
@@ -574,17 +574,16 @@ class AuthenticatedClient(PublicClient):
         """
         if side.lower() not in ["buy", "sell"]:
             raise ValueError("Allowed trade types are buy or sell, you entered {}".format(side.lower()))
-        if order_type.lower() not in ["limit", "otc"]:
+        if order_type.lower() not in ["limit", "market", "otc"]:
             raise ValueError("Allowed order type is limit, you entered {}".format(order_type.lower()))
         if order_type.lower() == "otc" and otc_address is None:
             raise ValueError("OTC Address is required when trade type is otc (over the counter).")
-            # order_params
         order_params = {
             "blockchain": self.blockchain,
             "pair": pair,
             "side": side,
-            "price": '{:.8f}'.format(price),
-            "want_amount": str(self.blockchain_amount[self.blockchain](amount)),
+            "price": '{:.8f}'.format(price) if order_type.lower() != "market" else None,
+            "quantity": str(self.blockchain_amount[self.blockchain](quantity)),
             "use_native_tokens": use_native_token,
             "order_type": order_type,
             "timestamp": get_epoch_milliseconds(),

--- a/switcheo/switcheo_client.py
+++ b/switcheo/switcheo_client.py
@@ -1,17 +1,52 @@
 # -*- coding:utf-8 -*-
 """
 Description:
-    Switcheo Client is designed to standardize interactions with the Python Client.  It can access the Public and Authenticated Clients and is designed to be more user friendly than the forward facing REST API's.
+    Switcheo Client is designed to standardize interactions with the Python Client.
+    It can access the Public and Authenticated Clients and is designed to be more user friendly than the
+    forward facing REST API's.
+    Ideally, more simplified/advanced trading functions will be built here (trailing stop, all or none, etc)
 Usage:
     from switcheo.switcheo_client import SwitcheoClient
 """
 
 from switcheo.utils import current_contract_hash
 from switcheo.authenticated_client import AuthenticatedClient
+from switcheo.public_client import PublicClient
 from switcheo.neo.utils import neo_get_scripthash_from_address
 
+contract_version_dict = {
+    "eth": 'V1',
+    "neo": 'V2'
+}
 
-class SwitcheoClient(AuthenticatedClient):
+network_dict = {
+    "neo": "neo",
+    "NEO": "neo",
+    "eth": "eth",
+    "ETH": "eth",
+    "ethereum": "eth",
+    "Ethereum": "eth"
+}
+
+url_dict = {
+    "main": 'https://api.switcheo.network/',
+    "test": 'https://test-api.switcheo.network/'
+}
+
+
+class SwitcheoClient(AuthenticatedClient, PublicClient):
+
+    def __init__(self,
+                 switcheo_network="test",
+                 blockchain_network="neo",
+                 private_key=None):
+        self.api_url = url_dict[switcheo_network]
+        self.blockchain = network_dict[blockchain_network]
+        self.contract_version = contract_version_dict[self.blockchain]
+        super().__init__(blockchain=self.blockchain,
+                         contract_version=self.contract_version,
+                         api_url=self.api_url)
+        self.private_key = private_key
 
     def order_history(self, address, pair=None):
         return self.get_orders(neo_get_scripthash_from_address(address=address), pair=pair)
@@ -45,3 +80,89 @@ class SwitcheoClient(AuthenticatedClient):
         for address in addresses:
             contract_dict[address] = self.balance_by_contract(address)
         return contract_dict
+
+    def limit_buy(self, price, quantity, pair, use_native_token=True):
+        """
+
+            limit_buy(price=0.0002, quantity=1000, pair='SWTH_NEO')
+            limit_buy(price=0.0000001, quantity=1000000, pair='JRC_ETH')
+
+        :param price:
+        :param quantity:
+        :param pair:
+        :param use_native_token:
+        :return:
+        """
+        if 'ETH' in pair:
+            use_native_token = False
+        return self.order(order_type="limit",
+                          side="buy",
+                          pair=pair,
+                          price=price,
+                          quantity=quantity,
+                          private_key=self.private_key,
+                          use_native_token=use_native_token)
+
+    def limit_sell(self, price, quantity, pair, use_native_token=True):
+        """
+
+            limit_sell(price=0.0006, quantity=500, pair='SWTH_NEO')
+            limit_sell(price=0.000001, quantity=100000, pair='JRC_ETH')
+
+        :param price:
+        :param quantity:
+        :param pair:
+        :param use_native_token:
+        :return:
+        """
+        if 'ETH' in pair:
+            use_native_token = False
+        return self.order(order_type="limit",
+                          side="sell",
+                          pair=pair,
+                          price=price,
+                          quantity=quantity,
+                          private_key=self.private_key,
+                          use_native_token=use_native_token)
+
+    def market_buy(self, quantity, pair, use_native_token=True):
+        """
+
+            market_buy(quantity=100, pair='SWTH_NEO')
+            market_buy(quantity=100000, pair='JRC_ETH')
+
+        :param quantity:
+        :param pair:
+        :param use_native_token:
+        :return:
+        """
+        if 'ETH' in pair:
+            use_native_token = False
+        return self.order(order_type="market",
+                          side="buy",
+                          pair=pair,
+                          price=0,
+                          quantity=quantity,
+                          private_key=self.private_key,
+                          use_native_token=use_native_token)
+
+    def market_sell(self, quantity, pair, use_native_token=True):
+        """
+
+            market_sell(quantity=100, pair='SWTH_NEO')
+            market_sell(quantity=100000, pair='JRC_ETH')
+
+        :param quantity:
+        :param pair:
+        :param use_native_token:
+        :return:
+        """
+        if 'ETH' in pair:
+            use_native_token = False
+        return self.order(order_type="market",
+                          side="sell",
+                          pair=pair,
+                          price=0,
+                          quantity=quantity,
+                          private_key=self.private_key,
+                          use_native_token=use_native_token)

--- a/switcheo/test_authenticated_client.py
+++ b/switcheo/test_authenticated_client.py
@@ -56,7 +56,7 @@ class TestAuthenticatedClient(unittest.TestCase):
 
     def test_create_and_cancel_order(self):
         order = ac.order(pair="SWTH_NEO", side="buy",
-                         price=0.00001, amount=10000, private_key=kp,
+                         price=0.00001, quantity=10000, private_key=kp,
                          use_native_token=True, order_type="limit")
         ac.cancel_order(order_id=order['id'], private_key=kp)
         testnet_scripthash = 'fea2b883725ef2d194c9060f606cd0a0468a2c59'
@@ -72,10 +72,10 @@ class TestAuthenticatedClient(unittest.TestCase):
         # Test side filter
         with self.assertRaises(ValueError):
             ac.order(pair="SWTH_NEO", side="test",
-                     price=0.0001, amount=100, private_key=kp,
+                     price=0.0001, quantity=100, private_key=kp,
                      use_native_token=True, order_type="limit")
         # Test order_type filter
         with self.assertRaises(ValueError):
             ac.order(pair="SWTH_NEO", side="buy",
-                     price=0.0001, amount=100, private_key=kp,
+                     price=0.0001, quantity=100, private_key=kp,
                      use_native_token=True, order_type="test")


### PR DESCRIPTION
Switcheo has added market orders and this change adds the market method to SwitcheoClient and enables it in the AuthenticatedClient.  Also, the want_amount parameter sent has been upgraded to quantity to be more straight forward with order amounts.