### PR TITLE
Updated order function to support atomic swap pairs + some bugfixes

### DIFF
--- a/switcheo/authenticated_client.py
+++ b/switcheo/authenticated_client.py
@@ -291,6 +291,10 @@ class AuthenticatedClient(PublicClient):
         :return: Dictionary with the result status of the deposit attempt.
         """
         create_deposit = self.create_deposit(asset=asset, amount=amount, private_key=private_key)
+        
+        if 'transaction' in create_deposit and 'invoke' in create_deposit['transaction']:
+            del create_deposit['transaction']['invoke']
+
         return self.execute_deposit(deposit_params=create_deposit, private_key=private_key)
 
     def create_deposit(self, asset, amount, private_key):
@@ -389,77 +393,6 @@ class AuthenticatedClient(PublicClient):
         api_params = self.sign_execute_deposit_function[self.blockchain](deposit_params, private_key)
         return self.request.post(path='/deposits/{}/broadcast'.format(deposit_id), json_data=api_params)
 
-    def order(self, pair, side, price, quantity, private_key, use_native_token=True, order_type="limit"):
-        """
-        This function is a wrapper function around the create and execute order functions to help make this processes
-        simpler for the end user by combining these requests in 1 step.
-        Execution of this function is as follows::
-
-            order(pair="SWTH_NEO", side="buy",
-                  price=0.0002, quantity=100, private_key=kp,
-                  use_native_token=True, order_type="limit")
-
-        The expected return result for this function is the same as the execute_order function::
-
-            {
-                'id': '4e6a59fd-d750-4332-aaf0-f2babfa8ad67',
-                'blockchain': 'neo',
-                'contract_hash': 'a195c1549e7da61b8da315765a790ac7e7633b82',
-                'address': 'fea2b883725ef2d194c9060f606cd0a0468a2c59',
-                'side': 'buy',
-                'offer_asset_id': 'c56f33fc6ecfcd0c225c4ab356fee59390af8560be0e930faebe74a6daff7c9b',
-                'want_asset_id': 'ab38352559b8b203bde5fddfa0b07d8b2525e132',
-                'offer_amount': '2000000',
-                'want_amount': '10000000000',
-                'transfer_amount': '0',
-                'priority_gas_amount': '0',
-                'use_native_token': True,
-                'native_fee_transfer_amount': 0,
-                'deposit_txn': None,
-                'created_at': '2018-08-05T10:38:37.714Z',
-                'status': 'processed',
-                'fills': [],
-                'makes': [
-                    {
-                        'id': 'e30a7fdf-779c-4623-8f92-8a961450d843',
-                        'offer_hash': 'b45ddfb97ade5e0363d9e707dac9ad1c530448db263e86494225a0025006f968',
-                        'available_amount': '2000000',
-                        'offer_asset_id': 'c56f33fc6ecfcd0c225c4ab356fee59390af8560be0e930faebe74a6daff7c9b',
-                        'offer_amount': '2000000',
-                        'want_asset_id': 'ab38352559b8b203bde5fddfa0b07d8b2525e132',
-                        'want_amount': '10000000000',
-                        'filled_amount': '0.0',
-                        'txn': None,
-                        'cancel_txn': None,
-                        'price': '0.0002',
-                        'status': 'confirming',
-                        'created_at': '2018-08-05T10:38:37.731Z',
-                        'transaction_hash': '5c4cb1e73b9f2e608b6e768e0654649a4d15e08a7fe63fc536c454fa563a2f0f',
-                        'trades': []
-                    }
-                ]
-            }
-
-        :param pair: The trading pair this order is being submitted for.
-        :type pair: str
-        :param side: The side of the trade being submitted i.e. buy or sell
-        :type side: str
-        :param price: The price target for this trade.
-        :type price: float
-        :param quantity: The amount of the asset being exchanged in the trade.
-        :type quantity: float
-        :param private_key: The Private Key (ETH) or KeyPair (NEO) for the wallet being used to sign deposit message.
-        :type private_key: KeyPair or str
-        :param use_native_token: Flag to indicate whether or not to pay fees with the Switcheo native token.
-        :type use_native_token: bool
-        :param order_type: The type of order being submitted, currently this can only be a limit order.
-        :type order_type: str
-        :return: Dictionary of the transaction on the order book.
-        """
-        create_order = self.create_order(private_key=private_key, pair=pair, side=side, price=price,
-                                         quantity=quantity, use_native_token=use_native_token,
-                                         order_type=order_type)
-        return self.execute_order(order_params=create_order, private_key=private_key)
 
     def order(self, pair, side, private_key, price=None, quantity=None, use_native_token=True, 
               order_type="limit", offer_amount=None, receiving_address=None, worst_acceptable_price=None):

--- a/switcheo/authenticated_client.py
+++ b/switcheo/authenticated_client.py
@@ -291,10 +291,6 @@ class AuthenticatedClient(PublicClient):
         :return: Dictionary with the result status of the deposit attempt.
         """
         create_deposit = self.create_deposit(asset=asset, amount=amount, private_key=private_key)
-        
-        if 'transaction' in create_deposit and 'invoke' in create_deposit['transaction']:
-            del create_deposit['transaction']['invoke']
-
         return self.execute_deposit(deposit_params=create_deposit, private_key=private_key)
 
     def create_deposit(self, asset, amount, private_key):

--- a/switcheo/ethereum/signatures.py
+++ b/switcheo/ethereum/signatures.py
@@ -206,7 +206,7 @@ def sign_execute_order(order_params, private_key):
     execute_params = {
         'signatures': {
             'fill_groups': sign_txn_array(messages=order_params['fill_groups'], private_key=private_key),
-            'fills': {},
+            'fills': sign_txn_array(messages=order_params['fills'], private_key=private_key),
             'makes': sign_txn_array(messages=order_params['makes'], private_key=private_key),
         }
     }

--- a/switcheo/neo/utils.py
+++ b/switcheo/neo/utils.py
@@ -10,7 +10,7 @@ import base58
 from neocore.Cryptography.Crypto import Crypto
 from neocore.KeyPair import KeyPair
 from neocore.Cryptography.Helper import scripthash_to_address
-from switcheo.utils import num2hexstring, stringify_message, reverse_hex
+from switcheo.utils import num2hexstring, stringify_message, reverse_hex, num2varint
 from switcheo.neo.transactions import serialize_transaction
 
 
@@ -33,7 +33,7 @@ def sign_txn_array(messages, private_key_hex):
 
 def encode_message(message):
     message_hex = binascii.hexlify(stringify_message(message).encode('utf-8')).decode()
-    message_hex_length = hex(int(len(message_hex) / 2))[2:]
+    message_hex_length = num2varint(len(message_hex) // 2)
     return '010001f0' + message_hex_length + message_hex + '0000'
 
 

--- a/switcheo/public_client.py
+++ b/switcheo/public_client.py
@@ -131,6 +131,75 @@ class PublicClient(object):
         }
         return self.request.get(path='/exchange/tokens', params=api_params)
 
+
+    def get_swap_pairs(self):
+        """
+        Retrieve available swap pairs on Switcheo Exchange.
+        Execution of this function is as follows::
+
+            get_swap_pairs()
+
+        The expected return result for this function is as follows::
+
+            [
+              "SWTH_ETH",
+              ...
+            ]
+
+        :return: List in the form of a JSON message with the available swap pairs on the Switcheo exchange.
+        """
+        return self.request.get(path='/exchange/swap_pairs')
+
+    def get_swap_pricing(self, pair):
+        """
+        Function to fetch information that can be used to calculate the price of swap pairs.
+        Execution of this function is as follows::
+
+            get_swap_pricing()
+
+        The expected return result for this function is as follows::
+
+            {
+                "buy": {
+                    "x": "449293223000000",
+                    "y": "122561935387988990000",
+                    "k": "55066246967587328805614770000000000"
+                },
+                "sell": {
+                    "x": "122561935387988990000",
+                    "y": "449293223000000",
+                    "k": "55066246967587328805614770000000000"
+                }
+            }
+
+        :param pair: The trading pair used to request pricing from.
+        :return: Dictionary in the form of a JSON message containing the pricing parameters.
+        """              
+        api_params = {
+            "pair": pair
+        }
+        return self.request.get(path='/exchange/swap_pricing', params=api_params)  
+
+    def get_atomic_swap_contracts(self):
+        """
+        Returns the current atomic swap contract hashes.
+        Please note that a different set of contract hashes should be used depending on the network you intend to interact with.
+        Execution of this function is as follows::
+
+            get_atomic_swap_contracts()
+
+        The expected return result for this function is as follows::
+
+            {
+                "ETH": {
+                    "V1": "<contract hash>"
+                }
+            }
+
+        :return: Dictionary in the form of a JSON message with the atomic swap contracts used on the Switcheo exchange.
+        """
+        return self.request.get(path='/exchange/atomic_swap_contracts')
+
     def get_candlesticks(self, pair, start_time, end_time, interval):
         """
         Function to fetch trading metrics from the past 24 hours for all trading pairs offered on the exchange.


### PR DESCRIPTION
- the order function now support all arguments to allow atomic swap trades. The function deduces whether a regular or swap trade invoked based on the arguments supplied, and handles the request accordingly. 
- a fix in message encoding for long messages.
- include 'fills' in the sign_execute_order function for ethereum. This is necessary to successfully execute ethereum orders. 